### PR TITLE
[상비약] 이미지Uri 추가

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/medicine/repository/MedicineRepository.java
@@ -69,6 +69,8 @@ public class MedicineRepository {
                             ? result.path("dosage_and_administration").get(0).asText("Unknown") : "Unknown");
                     String dosageFormsAndStrengths = translateIfNeeded(result.path("dosage_forms_and_strengths").isArray()
                             ? result.path("dosage_forms_and_strengths").get(0).asText("Unknown") : "Unknown");
+                    String splSetId = openFda.path("spl_set_id").isArray()
+                            ? openFda.path("spl_set_id").get(0).asText("Unknown") : "Unknown";
 
                     medicines.add(new MedicineResponseDTO(
                             brandName,
@@ -79,7 +81,8 @@ public class MedicineRepository {
                             purpose,
                             indications,
                             dosageAndAdministration,
-                            dosageFormsAndStrengths
+                            dosageFormsAndStrengths,
+                            splSetId
                     ));
                 }
             }

--- a/src/main/java/com/pharmquest/pharmquest/domain/medicine/web/dto/MedicineResponseDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/medicine/web/dto/MedicineResponseDTO.java
@@ -15,4 +15,6 @@ public class MedicineResponseDTO {
     private String indicationsAndUsage; // indications_and_usage
     private String dosageAndAdministration; // dosage_and_administration
     private String dosageFormsAndStrengths; // dosage_forms_and_strengths
+    private String  splSetId; //이미지 찾는 기준이 되는 약 코드
+
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/medicine/web/dto/MedicineResponseDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/medicine/web/dto/MedicineResponseDTO.java
@@ -16,5 +16,7 @@ public class MedicineResponseDTO {
     private String dosageAndAdministration; // dosage_and_administration
     private String dosageFormsAndStrengths; // dosage_forms_and_strengths
     private String  splSetId; //이미지 찾는 기준이 되는 약 코드
+    private String imgUrl; //
+
 
 }


### PR DESCRIPTION
### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #45

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- Devmail에서 fdaOpenAPI로 받은 spl_set_id로 해당 약의 이미지를 매칭에서 dto로 불러오도록 설정했습니다

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- repostiory에 번역, 이미지 매칭 코드가 모두 포함되어있기 때문에 로직을 좀 더 효율적으로 변경할 예정입니다
