### PR TITLE
[Feat] 약국 스크랩 구현

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/ListStringConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/ListStringConverter.java
@@ -1,0 +1,24 @@
+package com.pharmquest.pharmquest.domain.pharmacy.converter;
+
+import jakarta.persistence.AttributeConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListStringConverter implements AttributeConverter<List<String>, String> {
+
+    @Override // DB에 저장하는거 placeId -> db 문자열에 포함
+    public String convertToDatabaseColumn(List<String> placeIdList) {
+        // 문자열을 합칠 때마다 객체를 만드는 것을 막기 위해 StringBuilder 사용
+        StringBuilder sb = new StringBuilder();
+        placeIdList // List에 담긴 String들 모두 합침
+                .forEach(placeId -> sb.append(",").append(placeId));
+        return sb.toString();
+    }
+
+    @Override // DB 문자열 -> placeId 목록 : 약국 조회 때 쓰임
+    public List<String> convertToEntityAttribute(String placeIdString) {
+        return new ArrayList<>(List.of(","));
+    }
+
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/ListStringConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/ListStringConverter.java
@@ -9,16 +9,18 @@ public class ListStringConverter implements AttributeConverter<List<String>, Str
 
     @Override // DB에 저장하는거 placeId -> db 문자열에 포함
     public String convertToDatabaseColumn(List<String> placeIdList) {
-        // 문자열을 합칠 때마다 객체를 만드는 것을 막기 위해 StringBuilder 사용
-        StringBuilder sb = new StringBuilder();
-        placeIdList // List에 담긴 String들 모두 합침
-                .forEach(placeId -> sb.append(",").append(placeId));
-        return sb.toString();
+        if (placeIdList == null || placeIdList.isEmpty()) {
+            return "";
+        }
+        return String.join(",", placeIdList);
     }
 
     @Override // DB 문자열 -> placeId 목록 : 약국 조회 때 쓰임
     public List<String> convertToEntityAttribute(String placeIdString) {
-        return new ArrayList<>(List.of(","));
+        if (placeIdString == null || placeIdString.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        return List.of(placeIdString.split(","));
     }
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
@@ -1,0 +1,5 @@
+package com.pharmquest.pharmquest.domain.pharmacy.service;
+
+public interface PharmacyCommandService {
+    public Boolean scrapPharmacy(Long userId, Long pharmacyId);
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
@@ -1,5 +1,5 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
 public interface PharmacyCommandService {
-    public Boolean scrapPharmacy(Long userId, Long pharmacyId);
+    public Boolean scrapPharmacy(Long userId, String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -1,0 +1,22 @@
+package com.pharmquest.pharmquest.domain.pharmacy.service;
+
+import com.pharmquest.pharmquest.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PharmacyCommandServiceImpl implements PharmacyCommandService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Boolean scrapPharmacy(Long userId, Long pharmacyId) {
+
+        boolean userExist = userRepository.existsById(userId);
+
+        return null;
+    }
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -1,9 +1,15 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
+import com.pharmquest.pharmquest.domain.user.data.User;
 import com.pharmquest.pharmquest.domain.user.repository.UserRepository;
+import com.pharmquest.pharmquest.global.apiPayload.code.status.ErrorStatus;
+import com.pharmquest.pharmquest.global.apiPayload.exception.handler.CommonExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -13,10 +19,25 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
     private final UserRepository userRepository;
 
     @Override
-    public Boolean scrapPharmacy(Long userId, Long pharmacyId) {
+    public Boolean scrapPharmacy(Long userId, String placeId) {
 
-        boolean userExist = userRepository.existsById(userId);
+        System.out.println("service");
+        User user = userRepository.findById(userId).orElseThrow(() -> new CommonExceptionHandler(ErrorStatus.USER_NOT_FOUND));
+        List<String> pharmacyScraps = user.getPharmacyScraps();
 
-        return null;
+        // placeId 검증
+        if(placeId == null || placeId.isEmpty()) {
+            throw new CommonExceptionHandler(ErrorStatus.PHARMACY_BAD_PLACE_ID);
+        }
+
+        // 해당 약국이 이미 스크랩되어있는지 체크.
+        // 스크랩되지 않았어야 저장.
+        if (!pharmacyScraps.contains(placeId)) {
+            List<String> updatedPharmacyScraps = new ArrayList<>(pharmacyScraps);
+            updatedPharmacyScraps.add(placeId);
+            user.setPharmacyScraps(updatedPharmacyScraps);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
@@ -1,0 +1,27 @@
+package com.pharmquest.pharmquest.domain.pharmacy.web.controller;
+
+import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyCommandService;
+import com.pharmquest.pharmquest.domain.pharmacy.web.dto.PharmacyRequestDTO;
+import com.pharmquest.pharmquest.global.apiPayload.ApiResponse;
+import com.pharmquest.pharmquest.global.apiPayload.code.status.SuccessStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pharmacy")
+public class PharmacyController {
+
+    private final PharmacyCommandService pharmacyCommandService;
+
+    @PostMapping("/")
+    public ApiResponse<Void> scrapPharmacy(@RequestBody @Valid PharmacyRequestDTO.ScrapDto request){
+        pharmacyCommandService.scrapPharmacy(request.getUserId(), request.getPharmacyId());
+        return ApiResponse.noResultSuccess(SuccessStatus.PHARMACY_SCRAP);
+    }
+
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
@@ -4,6 +4,10 @@ import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyCommandService;
 import com.pharmquest.pharmquest.domain.pharmacy.web.dto.PharmacyRequestDTO;
 import com.pharmquest.pharmquest.global.apiPayload.ApiResponse;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +23,14 @@ public class PharmacyController {
     private final PharmacyCommandService pharmacyCommandService;
 
     @PostMapping("/")
+    @Operation(summary = "약국 스크랩", description = "memberId와 약국의 placeId로 약국을 스크랩합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PHARMACY201", description = "약국을 마이페이지에 성공적으로 스크랩했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "유저를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PHARMACY4001", description = "약국의 place_id가 올바르지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
     public ApiResponse<Void> scrapPharmacy(@RequestBody @Valid PharmacyRequestDTO.ScrapDto request){
-        pharmacyCommandService.scrapPharmacy(request.getUserId(), request.getPharmacyId());
+        pharmacyCommandService.scrapPharmacy(request.getUserId(), request.getPlaceId());
         return ApiResponse.noResultSuccess(SuccessStatus.PHARMACY_SCRAP);
     }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
@@ -1,5 +1,6 @@
 package com.pharmquest.pharmquest.domain.pharmacy.web.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -9,8 +10,8 @@ public class PharmacyRequestDTO {
     public static class ScrapDto{
         @NotNull
         private Long userId;
-        @NotNull
-        private Long pharmacyId;
+        @NotBlank
+        private String placeId;
     }
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
@@ -1,0 +1,16 @@
+package com.pharmquest.pharmquest.domain.pharmacy.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class PharmacyRequestDTO {
+
+    @Getter
+    public static class ScrapDto{
+        @NotNull
+        private Long userId;
+        @NotNull
+        private Long pharmacyId;
+    }
+
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/user/data/User.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/user/data/User.java
@@ -1,9 +1,9 @@
 package com.pharmquest.pharmquest.domain.user.data;
 
 import com.pharmquest.pharmquest.domain.mypage.domain.MedicineScrap;
-import com.pharmquest.pharmquest.domain.mypage.domain.PharmacyScrap;
 import com.pharmquest.pharmquest.domain.mypage.domain.SupplementScrap;
 import com.pharmquest.pharmquest.domain.mypage.domain.PostScrap;
+import com.pharmquest.pharmquest.domain.pharmacy.converter.ListStringConverter;
 import com.pharmquest.pharmquest.domain.post.data.mapping.PostLike;
 import com.pharmquest.pharmquest.domain.post.data.mapping.PostReport;
 import jakarta.persistence.*;
@@ -37,12 +37,13 @@ public class User {
     @CreationTimestamp
     private Timestamp createDate;
 
+    @Convert(converter = ListStringConverter.class)
+    @Column(columnDefinition = "varchar(100) default '{}'")
+    private List<String> pharmacyScraps; // 스크랩한 약국 목록을 문자열로 저장
+
     // Relationships
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MedicineScrap> medicineScraps;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PharmacyScrap> pharmacyScraps;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SupplementScrap> supplementScraps;
@@ -55,4 +56,5 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostReport> postReports;
+
 }

--- a/src/main/java/com/pharmquest/pharmquest/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/pharmquest/pharmquest/global/apiPayload/ApiResponse.java
@@ -20,9 +20,13 @@ public class ApiResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;
 
-    //공의 경우 응답 생성
+    //성공의 경우 응답 생성
     public static <T> ApiResponse<T> onSuccess(T result) {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> noResultSuccess(BaseCode code) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), null);
     }
 
     public static <T> ApiResponse<T> of(BaseCode code, T result) {

--- a/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,13 @@ public enum ErrorStatus implements BaseErrorCode {
     // posts
     ILLEGAL_COUNTRY(HttpStatus.BAD_REQUEST, "POST4001", "올바르지 않은 국가."),
     ILLEGAL_POST_CATEGORY(HttpStatus.BAD_REQUEST, "POST4002", "올바르지 않은 카테고리."),
+
+    // user
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 사용자입니다."),
+
+    // pharmacy
+    PHARMACY_BAD_PLACE_ID(HttpStatus.BAD_REQUEST, "PHARMACY4001", "약국의 place_id가 올바르지 않습니다."),
+
     ;
 
 

--- a/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/SuccessStatus.java
@@ -18,6 +18,7 @@ public enum SuccessStatus implements BaseCode {
 
     // pharmacy
     PHARMACY_SCRAP(HttpStatus.OK, "PHARMACY201", "약국을 마이페이지에 성공적으로 스크랩했습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/SuccessStatus.java
@@ -15,6 +15,9 @@ public enum SuccessStatus implements BaseCode {
 
     // home
     HOME_POSTS(HttpStatus.OK, "HOME201", "홈 게시글을 성공적으로 불러왔습니다."),
+
+    // pharmacy
+    PHARMACY_SCRAP(HttpStatus.OK, "PHARMACY201", "약국을 마이페이지에 성공적으로 스크랩했습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### ✅ Issue
Resolved #24 

## ⛏ 작업 내용
- 공통 응답(ApiResponse) 에 결과 없이 BaseCode만 넣는 응답 생성
- ListStringConverter : 엔티티와 DB사이에서 값을 convert 해줌  -> User의 pharmacyScraps와 DB 사이
- 약국 스크랩 기능 구현

## 📌 PR Point
- 약국을 저장할 때 마이페이지에 저장할 때 보이는 결과를 테이블에 저장할지, placeId만 받아서 저장할 지 고민했음
- User에 사용자가 저장한 약국의 placeId를 필드로 저장하기로 함
- User 테이블의 postScraps 컬럼에 placeId를 하나의 문자열로 나열
- 마이페이지에서 조회할 때는 converter로 List 형태로 변환
<img width="306" alt="image" src="https://github.com/user-attachments/assets/0f581d6a-0d06-42b4-9f1f-dd361714d8cc" />
