### PR TITLE
[Refactor] 약국 조회 api 수정

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/ScrapServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/ScrapServiceImpl.java
@@ -5,7 +5,6 @@ import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
 import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyDetailsService;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +13,6 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-@Slf4j
 public class ScrapServiceImpl implements ScrapService {
 
     private final PharmacyDetailsService pharmacyDetailsService;

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/ScrapServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/ScrapServiceImpl.java
@@ -1,9 +1,11 @@
 package com.pharmquest.pharmquest.domain.mypage.service;
 
 import com.pharmquest.pharmquest.domain.mypage.web.dto.ScrapResponseDTO;
+import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
 import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyDetailsService;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class ScrapServiceImpl implements ScrapService {
 
     private final PharmacyDetailsService pharmacyDetailsService;
@@ -20,10 +23,11 @@ public class ScrapServiceImpl implements ScrapService {
     public List<ScrapResponseDTO.PharmacyDto> getPharmacies(User user, String country) {
 
         List<String> pharmacyPlaceIdList = user.getPharmacyScraps();
+        String findingCountryName = PharmacyCountry.getCountryByName(country).getGoogleName(); // Query String으로 입력받은 국가의 google에 등록된 이름으로 변경
 
         return pharmacyPlaceIdList.stream()
-                .map(pharmacyDetailsService::getPharmacyByPlaceId)
-                .filter(pharmacyDto -> country.equals(pharmacyDto.getCountry()) || country.equals("all"))
+                .map(pharmacyDetailsService::getPharmacyDtoByPlaceId)
+                .filter(pharmacyDto -> findingCountryName.equals(pharmacyDto.getCountry()) || findingCountryName.equals("all"))
                 .toList();
 
     }

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/ScrapResponseDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/ScrapResponseDTO.java
@@ -13,6 +13,8 @@ public class ScrapResponseDTO {
     @Getter
     public static class PharmacyDto {
         private String name;
+        @JsonProperty("place_id")
+        private String placeId;
         @JsonProperty(value = "open_now")
         private Boolean openNow;
         private String region;

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/PlaceIdConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/PlaceIdConverter.java
@@ -6,7 +6,7 @@ import jakarta.persistence.Converter;
 import java.util.ArrayList;
 import java.util.List;
 
-@Converter
+@Converter/**/
 public class PlaceIdConverter implements AttributeConverter<List<String>, String> {
 
     @Override // DB에 저장하는거 placeId -> db 문자열에 포함

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/PlaceIdConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/converter/PlaceIdConverter.java
@@ -1,11 +1,13 @@
 package com.pharmquest.pharmquest.domain.pharmacy.converter;
 
 import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class ListStringConverter implements AttributeConverter<List<String>, String> {
+@Converter
+public class PlaceIdConverter implements AttributeConverter<List<String>, String> {
 
     @Override // DB에 저장하는거 placeId -> db 문자열에 포함
     public String convertToDatabaseColumn(List<String> placeIdList) {

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
@@ -7,17 +7,19 @@ import java.util.Arrays;
 @Getter
 public enum PharmacyCountry {
 
-    KOREA("South Korea", "korea"),
-    USA("United States", "usa"),
-    ALL("all", "all")
+    KOREA("South Korea", "korea", "ko"),
+    USA("United States", "usa", "en"),
+    ALL("all", "all", "en")
     ;
 
     private final String googleName; // 구글에 등록된 국가 이름 형식
     private final String paramName; // query string으로 받을 국가 이름 형식
+    private final String lang;
 
-    PharmacyCountry(String googleName, String paramName) {
+    PharmacyCountry(String googleName, String paramName, String lang) {
         this.googleName = googleName;
         this.paramName = paramName;
+        this.lang = lang;
     }
 
     // query string 으로 받은 국가 이름을 PharmacyCountry로 반환. 해당하는거 없을 경우 '전체' 반환
@@ -26,6 +28,14 @@ public enum PharmacyCountry {
                 .filter(country -> name.equals(country.paramName))
                 .findFirst()
                 .orElse(ALL);
+    }
+
+    public static String getLanguage(String googleName) {
+        PharmacyCountry pharmacyCountry = Arrays.stream(values())
+                .filter(country -> googleName.equals(country.googleName))
+                .findFirst()
+                .orElse(ALL);
+        return pharmacyCountry.lang;
     }
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
@@ -1,0 +1,31 @@
+package com.pharmquest.pharmquest.domain.pharmacy.data.enums;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum PharmacyCountry {
+
+    KOREA("South Korea", "korea"),
+    USA("United States", "usa"),
+    ALL("all", "all")
+    ;
+
+    private final String googleName; // 구글에 등록된 국가 이름 형식
+    private final String paramName; // query string으로 받을 국가 이름 형식
+
+    PharmacyCountry(String googleName, String paramName) {
+        this.googleName = googleName;
+        this.paramName = paramName;
+    }
+
+    // query string 으로 받은 국가 이름을 PharmacyCountry로 반환. 해당하는거 없을 경우 '전체' 반환
+    public static PharmacyCountry getCountryByName(String name) {
+        return Arrays.stream(values())
+                .filter(country -> name.equals(country.paramName))
+                .findFirst()
+                .orElse(ALL);
+    }
+
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -21,7 +21,6 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
     @Override
     public Boolean scrapPharmacy(User user, String placeId) {
 
-        System.out.println("service");
         List<String> pharmacyScraps = user.getPharmacyScraps();
         List<String> updatedPharmacyScraps = new ArrayList<>(pharmacyScraps);
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
@@ -6,5 +6,5 @@ import com.pharmquest.pharmquest.domain.mypage.web.dto.ScrapResponseDTO;
 public interface PharmacyDetailsService {
     public Boolean isPharmacyByPlaceId(String placeId);
 
-    public ScrapResponseDTO.PharmacyDto getPharmacyByPlaceId(String placeId);
+    public ScrapResponseDTO.PharmacyDto getPharmacyDtoByPlaceId(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -39,13 +39,14 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
 
     // placeId로 상세정보를 불러와 Dto로 변환
     @Override
-    public ScrapResponseDTO.PharmacyDto getPharmacyByPlaceId(String placeId) {
+    public ScrapResponseDTO.PharmacyDto getPharmacyDtoByPlaceId(String placeId) {
 
         GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
         GooglePlaceDetailsResponse.Result detailsResult = response.getResult();
 
         return ScrapResponseDTO.PharmacyDto.builder()
                 .name(detailsResult.getName())
+                .placeId(placeId)
                 .openNow(detailsResult.getOpeningHours().getOpenNow())
                 .region(detailsResult.getFormattedAddress())
                 .latitude(detailsResult.getGeometry().getLocation().getLat())

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -48,7 +48,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
                 .name(detailsResult.getName())
                 .placeId(placeId)
                 .openNow(detailsResult.getOpeningHours().getOpenNow())
-                .region(detailsResult.getFormattedAddress())
+                .region(detailsResult.getLocation())
                 .latitude(detailsResult.getGeometry().getLocation().getLat())
                 .longitude(detailsResult.getGeometry().getLocation().getLng())
                 .country(getCountryName(response))

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/controller/PharmacyController.java
@@ -1,14 +1,12 @@
 package com.pharmquest.pharmquest.domain.pharmacy.web.controller;
 
 import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyCommandService;
-import com.pharmquest.pharmquest.domain.pharmacy.web.dto.PharmacyRequestDTO;
 import com.pharmquest.pharmquest.domain.token.JwtUtil;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import com.pharmquest.pharmquest.global.apiPayload.ApiResponse;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,17 +18,17 @@ public class PharmacyController {
     private final PharmacyCommandService pharmacyCommandService;
     private final JwtUtil jwtUtil;
 
-    @PatchMapping("/")
+    @PatchMapping("/{place_id}")
     @Operation(summary = "약국 스크랩 API", description = "memberId와 약국의 placeId로 약국을 스크랩합니다.<br>만약 이미 저장된 약국을 저장하려고 할 경우 스크랩이 해제됩니다.<br>결과값은 없습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PHARMACY201", description = "약국을 마이페이지에 성공적으로 스크랩했습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PHARMACY202", description = "약국을 스크랩을 해제했습니다."),
     })
     public ApiResponse<Void> scrapPharmacy(@RequestHeader(value = "Authorization") String authorizationHeader
-                                          ,@RequestBody @Valid PharmacyRequestDTO.ScrapDto request) {
+                                          ,@PathVariable("place_id") String placeId) {
 
         User user = jwtUtil.getUserFromHeader(authorizationHeader);
-        Boolean scrap = pharmacyCommandService.scrapPharmacy(user, request.getPlaceId());
+        Boolean scrap = pharmacyCommandService.scrapPharmacy(user, placeId);
 
         if (scrap) { // scrap이 true면 스크랩 동작 성공, scrap이 false면 스크랩 취소 동작 성공
             return ApiResponse.noResultSuccess(SuccessStatus.PHARMACY_SCRAP);

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -64,10 +63,11 @@ public class GooglePlaceDetailsResponse {
         }
 
         // 지역 반환
-        public String getLocation() {
+        public List<String> getEnglishLocationList() {
 
             if (addressComponents == null || addressComponents.isEmpty()) {
-                return "Unknown";
+//                return "Unknown";
+                return List.of("Unknown");
             }
 
             // 지역 키워드 중 political 가진 country가 아닌 키워드 추출하여 list에 저장
@@ -79,16 +79,18 @@ public class GooglePlaceDetailsResponse {
 
             int size = locationList.size();
             if (size == 0) {
-                return "Unknown";
+//                return "Unknown";
+                return List.of("Unknown");
             }
 
             // 지역 키워드를 규모 큰 순서로 3개 이하가 되도록 설정
             locationList =  locationList.subList(Math.max(0, size - 3), size);
-            String listString = locationList.toString();
+            return locationList;
+//            String listString = locationList.toString();
 
             // listString 얖옆에 [] 제거, 중간에 ',' 제거
-            listString = listString.substring(1, listString.length()-1).replaceAll(",", "");
-            return listString;
+//            listString = listString.substring(1, listString.length()-1).replaceAll(",", "");
+//            return listString;
         }
 
     }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -61,6 +62,35 @@ public class GooglePlaceDetailsResponse {
         public List<AddressComponent> getAddressComponents() {
             return addressComponents == null ? List.of() : addressComponents;
         }
+
+        // 지역 반환
+        public String getLocation() {
+
+            if (addressComponents == null || addressComponents.isEmpty()) {
+                return "Unknown";
+            }
+
+            // 지역 키워드 중 political 가진 country가 아닌 키워드 추출하여 list에 저장
+            List<String> locationList = addressComponents.stream()
+                    .filter(component -> component.getTypes().contains("political") && !component.getTypes().contains("country"))
+                    .map(AddressComponent::getLongName)
+                    .map(String::trim)
+                    .toList();
+
+            int size = locationList.size();
+            if (size == 0) {
+                return "Unknown";
+            }
+
+            // 지역 키워드를 규모 큰 순서로 3개 이하가 되도록 설정
+            locationList =  locationList.subList(Math.max(0, size - 3), size);
+            String listString = locationList.toString();
+
+            // listString 얖옆에 [] 제거, 중간에 ',' 제거
+            listString = listString.substring(1, listString.length()-1).replaceAll(",", "");
+            return listString;
+        }
+
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -111,12 +141,12 @@ public class GooglePlaceDetailsResponse {
 
         @JsonProperty("open")
         public Time getOpen() {
-            return open == null ? new Time() : open;
+            return open;
         }
 
         @JsonProperty("close")
         public Time getClose() {
-            return close == null ? new Time() : close;
+            return close;
         }
     }
 
@@ -128,12 +158,12 @@ public class GooglePlaceDetailsResponse {
 
         @JsonProperty("day")
         public Integer getDay() {
-            return day == null ? 0 : day;
+            return day == null ? null : day;
         }
 
         @JsonProperty("time")
         public String getTime() {
-            return time == null ? "" : time;
+            return time == null ? null : time;
         }
     }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/PharmacyRequestDTO.java
@@ -1,18 +1,10 @@
 package com.pharmquest.pharmquest.domain.pharmacy.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 public class PharmacyRequestDTO {
-
-    @Getter
-    public static class ScrapDto{
-        @NotBlank
-        @JsonProperty(value = "place_id")
-        private String placeId;
-    }
 
     @Getter
     public static class FindDto {

--- a/src/main/java/com/pharmquest/pharmquest/domain/user/data/User.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/user/data/User.java
@@ -3,7 +3,7 @@ package com.pharmquest.pharmquest.domain.user.data;
 import com.pharmquest.pharmquest.domain.mypage.data.MedicineScrap;
 import com.pharmquest.pharmquest.domain.mypage.data.SupplementScrap;
 import com.pharmquest.pharmquest.domain.mypage.data.PostScrap;
-import com.pharmquest.pharmquest.domain.pharmacy.converter.ListStringConverter;
+import com.pharmquest.pharmquest.domain.pharmacy.converter.PlaceIdConverter;
 import com.pharmquest.pharmquest.domain.post.data.mapping.PostLike;
 import com.pharmquest.pharmquest.domain.post.data.mapping.PostReport;
 import jakarta.persistence.*;
@@ -11,7 +11,6 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +41,7 @@ public class User {
     private Timestamp createDate;
 
     @Lob
-    @Convert(converter = ListStringConverter.class)
+    @Convert(converter = PlaceIdConverter.class)
     @Column(columnDefinition = "TEXT")
     private List<String> pharmacyScraps; // 스크랩한 약국 목록을 문자열로 저장
 

--- a/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/pharmquest/pharmquest/global/apiPayload/code/status/ErrorStatus.java
@@ -19,13 +19,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // pharmacy
     PHARMACY_BAD_PLACE_ID(HttpStatus.BAD_REQUEST, "PHARMACY4001", "약국의 place_id가 올바르지 않습니다."),
-    PLACE_NO_RESULT(HttpStatus.BAD_REQUEST, "PHARMACY4001", "해당 place_id에 해당하는 장소가 없습니다"),
-    NOT_A_PHARMACY(HttpStatus.BAD_REQUEST, "PHARMACY4002", "해당 place_id에 해당하는 장소가 약국이 아닙니다."),
+    PLACE_NO_RESULT(HttpStatus.BAD_REQUEST, "PHARMACY4002", "해당 place_id에 해당하는 장소가 없습니다"),
+    NOT_A_PHARMACY(HttpStatus.BAD_REQUEST, "PHARMACY4003", "해당 place_id에 해당하는 장소가 약국이 아닙니다."),
 
     PHARMACY_UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PHARMACY5000", "알 수 없는 오류입니다."),
     PHARMACY_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PHARMACY5001", "google api 요청이 잘못되었습니다. 관리자 문의 바랍니다"),
-
-    PHARMACY_SCRAP_MAX_EXCEED(HttpStatus.INTERNAL_SERVER_ERROR, "MYPAGE5001", "약국의 최대 스크랩 수를 초과했습니다."),
+    PHARMACY_SCRAP_MAX_EXCEED(HttpStatus.INTERNAL_SERVER_ERROR, "PHARMACY5002", "약국의 최대 스크랩 수를 초과했습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### ✅ Issue
Resolved #65 

## ⛏ 작업 내용
- api에 각 약국의 placeId담기도록 수정
- placeId를 Request Body -> Path Variable 방식으로 수정
- 스크랩된 약국 조회 시, query string에 입력될 국가 이름 간소화.
- query String의 country에 usa, korea 외의 것 입력 시 전체 국가에 대해 조회
- 약국 장소 반환 범위 수정

## 📌 PR Point
- 약국 조회할 때 Query String의 country 속성에 국가 이름을 입력할 때, South Korea -> korea, United States -> usa 이렇게 입력하도록 변경. 그 외의 것을 입력하면 전체 조회.
- 스크랩된 약국 조회 시 약국의 장소를 반환할 때의 반환할 지역 범위 설정
