### PR TITLE
feat : 약국 장소  번역

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/enums/PharmacyCountry.java
@@ -7,9 +7,9 @@ import java.util.Arrays;
 @Getter
 public enum PharmacyCountry {
 
-    KOREA("South Korea", "korea", "ko"),
+    KOREA("South Korea","korea", "ko"),
     USA("United States", "usa", "en"),
-    ALL("all", "all", "en")
+    ALL("all",  "all", "en"),
     ;
 
     private final String googleName; // 구글에 등록된 국가 이름 형식

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
@@ -62,11 +62,10 @@ public class GooglePlaceDetailsResponse {
             return addressComponents == null ? List.of() : addressComponents;
         }
 
-        // 지역 반환
-        public List<String> getEnglishLocationList() {
+        // 지역 목록( 범위별 명칭 )을 리스트에 담아 반환
+        public List<String> getLocationList() {
 
             if (addressComponents == null || addressComponents.isEmpty()) {
-//                return "Unknown";
                 return List.of("Unknown");
             }
 
@@ -79,18 +78,12 @@ public class GooglePlaceDetailsResponse {
 
             int size = locationList.size();
             if (size == 0) {
-//                return "Unknown";
                 return List.of("Unknown");
             }
 
             // 지역 키워드를 규모 큰 순서로 3개 이하가 되도록 설정
             locationList =  locationList.subList(Math.max(0, size - 3), size);
             return locationList;
-//            String listString = locationList.toString();
-
-            // listString 얖옆에 [] 제거, 중간에 ',' 제거
-//            listString = listString.substring(1, listString.length()-1).replaceAll(",", "");
-//            return listString;
         }
 
     }


### PR DESCRIPTION
### ✅ Issue
Resolved #112 

## ⛏ 작업 내용
- 약국의 장소를 번역
- 한국의 경우 한글, 그 외의 국가는 영어로 번역
- 한국의 경우, 한국식으로 표기 ( 영문 표기를 거꾸로 처리 )

## 📌 PR Point
- 국가 요청 : Query String
- 국가 구분 : Enum ( PharmacyCountry )
- 번역 : TranslationService
