### PR TITLE
[Feat] 스크랩된 약국 목록 이미지 처리

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/MyPageResponseDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/MyPageResponseDTO.java
@@ -1,7 +1,6 @@
 package com.pharmquest.pharmquest.domain.mypage.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.pharmquest.pharmquest.domain.pharmacy.web.dto.GooglePlaceDetailsResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -26,7 +26,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
     private final WebClient webClient;
     private final String GOOGLE_PLACES_API_URL = "https://maps.googleapis.com/maps/api/place/details/json";
     private final String GOOGLE_PLACE_IMG_URL = "https://maps.googleapis.com/maps/api/place/photo?";
-    private final int IMG_MAX_SIZE = 86;
+    private final int IMG_MAX_SIZE = 200;
     private final TranslationService translationService;
 
     @Value("${place.details.api-key}")
@@ -65,7 +65,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
                 .longitude(detailsResult.getGeometry().getLocation().getLng())
                 .country(getCountryName(response))
 //                .periods(detailsResult.getOpeningHours().getPeriods())
-                .imgUrl(getImageBase64(getPhotoReference(response)))
+                .imgUrl(getImageURL(getPhotoReference(response)))
                 .build();
     }
 
@@ -133,13 +133,13 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
     }
 
     // photo_reference과 api key 이용하여 이미미 요청 후 -> Base64 인코딩된 url 반환
-    private String getImageBase64(String photoReference) {
+    private String getImageURL(String photoReference) {
         String url = GOOGLE_PLACE_IMG_URL + "maxwidth=" + IMG_MAX_SIZE + "&maxheight" + IMG_MAX_SIZE + "&photo_reference=" + photoReference + "&key=" + API_KEY;
         try {
             byte[] imageBytes = downloadImage(url);
             return "data:image/jpeg;base64," + Base64.getEncoder().encodeToString(imageBytes);
-        }catch (IOException e) {
-            return "기본 IMG";
+        }catch (Exception e) { // 문제 있으면 기본 사진 반환
+            return "https://umc-pharmquest.s3.ap-northeast-2.amazonaws.com/d09fa082-76d2-4c17-ad0a-e4800814ec61_pharm_default_img_1.jpg";
         }
     }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/web/dto/GooglePlaceDetailsResponse.java
@@ -33,6 +33,7 @@ public class GooglePlaceDetailsResponse {
         private OpeningHours openingHours;
         private Location geometry;
         private List<AddressComponent> addressComponents;
+        private List<Photo> photos;
 
         public List<String> getTypes() {
             return types;
@@ -61,6 +62,11 @@ public class GooglePlaceDetailsResponse {
         @JsonProperty("address_components")
         public List<AddressComponent> getAddressComponents() {
             return addressComponents == null ? List.of() : addressComponents;
+        }
+
+        @JsonProperty("photos") // Google Place API의 "photos" 필드 매핑
+        public List<Photo> getPhotos() {
+            return photos == null ? List.of() : photos;
         }
 
         // 지역 목록( 범위별 명칭 )을 리스트에 담아 반환
@@ -190,6 +196,35 @@ public class GooglePlaceDetailsResponse {
         @JsonProperty("lng")
         public Double getLng() {
             return lng == null ? 0 : lng;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Photo {
+
+        private int height;
+        private int width;
+        private String photoReference;
+        private List<String> htmlAttributions;
+
+        @JsonProperty("height")
+        public int getHeight() {
+            return height;
+        }
+
+        @JsonProperty("width")
+        public int getWidth() {
+            return width;
+        }
+
+        @JsonProperty("photo_reference")
+        public String getPhotoReference() {
+            return photoReference == null ? "" : photoReference;
+        }
+
+        @JsonProperty("html_attributions")
+        public List<String> getHtmlAttributions() {
+            return htmlAttributions == null ? List.of() : htmlAttributions;
         }
     }
 }


### PR DESCRIPTION
### ✅ Issue
Resolved #131 

## ⛏ 작업 내용
- 스크랩된 약국 목록 조회 시 나오는 이미지 처리
- 각 약국의 사진들 중 하나만 반환
- Base64 형태로 인코딩하여 반환 -> api key 보호
- 사진 없을 경우에는 기본 이미지로 대체

## 📌 PR Point
- s3에 이미지 업로드했는데, 이미지 url을 그대로 사용하면 되는지 고민...
