### PR TITLE
[Refactor] 스크랩 약국 조회 방식 변경

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
@@ -2,6 +2,9 @@ package com.pharmquest.pharmquest.domain.mypage.converter;
 
 import com.pharmquest.pharmquest.domain.medicine.data.Medicine;
 import com.pharmquest.pharmquest.domain.mypage.web.dto.MyPageResponseDTO;
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
+import com.pharmquest.pharmquest.domain.pharmacy.service.PharmacyDetailsService;
+import com.pharmquest.pharmquest.domain.pharmacy.web.dto.GooglePlaceDetailsResponse;
 import com.pharmquest.pharmquest.domain.post.data.Post;
 import com.pharmquest.pharmquest.domain.post.data.mapping.Comment;
 import com.pharmquest.pharmquest.domain.supplements.data.Enum.CategoryKeyword;
@@ -19,6 +22,8 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class MyPageConverter {
+
+    private final PharmacyDetailsService pharmacyDetailsService;
 
     public MyPageResponseDTO.SupplementsResponseDto toSupplementsDto(Supplements supplements) {
         if (supplements == null) {
@@ -102,6 +107,18 @@ public class MyPageConverter {
                 .commentWriter(comment.getUser().getEmail().substring(0, comment.getUser().getEmail().indexOf("@")))
                 .postTitle(comment.getPost().getTitle())
                 .createdAt(comment.getCreatedAt().toLocalDate())
+                .build();
+    }
+
+    public MyPageResponseDTO.PharmacyDto toPharmacyDto(Pharmacy pharmacy) {
+
+        return MyPageResponseDTO.PharmacyDto.builder()
+                .name(pharmacy.getName())
+                .placeId(pharmacy.getPlaceId())
+                .region(pharmacy.getRegion())
+                .latitude(pharmacy.getLatitude())
+                .longitude(pharmacy.getLongitude())
+                .imgUrl(pharmacyDetailsService.getImgURLByPlaceId(pharmacy.getPlaceId()))
                 .build();
     }
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/MyPageResponseDTO.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/web/dto/MyPageResponseDTO.java
@@ -6,7 +6,6 @@ import com.pharmquest.pharmquest.domain.supplements.data.Supplements;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -63,13 +62,9 @@ public class MyPageResponseDTO {
         private String name;
         @JsonProperty("place_id")
         private String placeId;
-//        @JsonProperty(value = "open_now")
-//        private Boolean openNow;
         private String region;
         private Double latitude;
         private Double longitude;
-        private String country;
-//        private List<GooglePlaceDetailsResponse.Period> periods;
         @JsonProperty(value = "img_url")
         private String imgUrl;
     }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/ImageUtil.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/ImageUtil.java
@@ -20,17 +20,21 @@ public class ImageUtil {
     private final int IMG_MAX_SIZE = 200;
 
     // photo_reference과 api key 이용하여 이미미 요청 후 -> Base64 인코딩된 url 반환
-    public String getImageURL(GooglePlaceDetailsResponse response ) {
+    public String getPharmacyImageURL(GooglePlaceDetailsResponse response ) {
 
         String photoReference = getPhotoReference(response);
 
         String url = GOOGLE_PLACE_IMG_URL + "maxwidth=" + IMG_MAX_SIZE + "&maxheight" + IMG_MAX_SIZE + "&photo_reference=" + photoReference + "&key=" + API_KEY;
         try {
-            byte[] imageBytes = downloadImage(url);
-            return "data:image/jpeg;base64," + Base64.getEncoder().encodeToString(imageBytes);
+            return encodeToBase64(url);
         }catch (Exception e) { // 문제 있으면 기본 사진 반환
             return "https://umc-pharmquest.s3.ap-northeast-2.amazonaws.com/d09fa082-76d2-4c17-ad0a-e4800814ec61_pharm_default_img_1.jpg";
         }
+    }
+
+    private String encodeToBase64(String url) throws IOException {
+        byte[] imageBytes = downloadImage(url);
+        return "data:image/jpeg;base64," + Base64.getEncoder().encodeToString(imageBytes);
     }
 
     // 여러 사진들 중 하나의 photo_reference 반환

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
@@ -34,8 +34,5 @@ public class Pharmacy extends BaseEntity {
     @Column(nullable = false)
     private Double longitude;
 
-    @Column(nullable = false)
-    private String imgUrl;
-
 }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
@@ -1,0 +1,41 @@
+package com.pharmquest.pharmquest.domain.pharmacy.data;
+
+import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
+import com.pharmquest.pharmquest.global.data.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Pharmacy extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String placeId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String region;
+
+    @Enumerated(EnumType.STRING)
+    private PharmacyCountry country;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Column(nullable = false)
+    private String imgUrl;
+
+}
+

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
@@ -1,0 +1,10 @@
+package com.pharmquest.pharmquest.domain.pharmacy.repository;
+
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PharmacyRepository extends JpaRepository<Pharmacy, Long> {
+
+    public Boolean existsByPlaceId(String placeId);
+
+}

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
@@ -2,9 +2,17 @@ package com.pharmquest.pharmquest.domain.pharmacy.repository;
 
 import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PharmacyRepository extends JpaRepository<Pharmacy, Long> {
 
     public Boolean existsByPlaceId(String placeId);
+
+    @Query(value = "SELECT * FROM pharmacy WHERE place_id IN (:placeIds)", nativeQuery = true)
+    List<Pharmacy> findAllByPlaceIds(@Param("placeIds") List<String> placeIds);
+
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
@@ -1,8 +1,10 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.SuccessStatus;
 
 public interface PharmacyCommandService {
     public SuccessStatus scrapPharmacy(User user, String placeId);
+    public Pharmacy savePharmacy(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -32,10 +32,8 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
         boolean isScraped = true;
 
         // 테이블에 약국 정보 이미 있는지 체크 후, 없다면 저장
-        Boolean isExist = pharmacyRepository.existsByPlaceId(placeId);
-        if (!isExist) {
-            Pharmacy pharmacy = pharmacyDetailsService.getPharmacyByPlaceId(placeId);
-            pharmacyRepository.save(pharmacy);
+        if (!pharmacyRepository.existsByPlaceId(placeId)){
+            savePharmacy(placeId);
         }
 
         // 해당 약국이 이미 스크랩되어있는지 체크.
@@ -66,5 +64,11 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
         userRepository.save(user);
         return isScraped ? SuccessStatus.PHARMACY_SCRAP : SuccessStatus.PHARMACY_UNSCRAP;
 
+    }
+
+    @Override
+    public Pharmacy savePharmacy(String placeId) {
+        Pharmacy pharmacy = pharmacyDetailsService.getPharmacyByPlaceId(placeId);
+        return pharmacyRepository.save(pharmacy);
     }
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
+import com.pharmquest.pharmquest.domain.pharmacy.repository.PharmacyRepository;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import com.pharmquest.pharmquest.domain.user.repository.UserRepository;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.ErrorStatus;
@@ -19,6 +21,7 @@ import java.util.List;
 public class PharmacyCommandServiceImpl implements PharmacyCommandService {
 
     private final PharmacyDetailsService pharmacyDetailsService;
+    private final PharmacyRepository pharmacyRepository;
     private final UserRepository userRepository;
 
     @Override
@@ -27,6 +30,13 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
         List<String> pharmacyScraps = user.getPharmacyScraps();
         List<String> updatedPharmacyScraps = new ArrayList<>(pharmacyScraps);
         boolean isScraped = true;
+
+        // 테이블에 약국 정보 이미 있는지 체크 후, 없다면 저장
+        Boolean isExist = pharmacyRepository.existsByPlaceId(placeId);
+        if (!isExist) {
+            Pharmacy pharmacy = pharmacyDetailsService.getPharmacyByPlaceId(placeId);
+            pharmacyRepository.save(pharmacy);
+        }
 
         // 해당 약국이 이미 스크랩되어있는지 체크.
         if(!pharmacyScraps.contains(placeId)) { // 스크랩 되어있지 않았다면 저장

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
@@ -1,11 +1,10 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
-import com.pharmquest.pharmquest.domain.mypage.web.dto.MyPageResponseDTO;
 import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 
 
 public interface PharmacyDetailsService {
     public Boolean isPharmacyByPlaceId(String placeId);
-    public MyPageResponseDTO.PharmacyDto getPharmacyDtoByPlaceId(String placeId);
     public Pharmacy getPharmacyByPlaceId(String placeId);
+    public String getImgURLByPlaceId(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
@@ -1,10 +1,11 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
 import com.pharmquest.pharmquest.domain.mypage.web.dto.MyPageResponseDTO;
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 
 
 public interface PharmacyDetailsService {
     public Boolean isPharmacyByPlaceId(String placeId);
-
     public MyPageResponseDTO.PharmacyDto getPharmacyDtoByPlaceId(String placeId);
+    public Pharmacy getPharmacyByPlaceId(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -1,7 +1,6 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
 import com.pharmquest.pharmquest.domain.medicine.service.TranslationService;
-import com.pharmquest.pharmquest.domain.mypage.web.dto.MyPageResponseDTO;
 import com.pharmquest.pharmquest.domain.pharmacy.ImageUtil;
 import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
@@ -62,7 +61,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
     @Override
     public String getImgURLByPlaceId(String placeId) {
         GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
-        return imageUtil.getImageURL(response);
+        return imageUtil.getPharmacyImageURL(response);
     }
 
     // 장소 번역

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -44,25 +44,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
         return false;
     }
 
-    // placeId로 상세정보를 불러와 Dto로 변환
-    @Override
-    public MyPageResponseDTO.PharmacyDto getPharmacyDtoByPlaceId(String placeId) {
-
-        GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
-        GooglePlaceDetailsResponse.Result detailsResult = response.getResult();
-        return MyPageResponseDTO.PharmacyDto.builder()
-                .name(detailsResult.getName())
-                .placeId(placeId)
-//                .openNow(detailsResult.getOpeningHours().getOpenNow()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
-                .region(getTranslatedLocation(response, detailsResult.getLocationList()))
-                .latitude(detailsResult.getGeometry().getLocation().getLat())
-                .longitude(detailsResult.getGeometry().getLocation().getLng())
-                .country(getCountryName(response))
-//                .periods(detailsResult.getOpeningHours().getPeriods()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
-                .imgUrl(imageUtil.getImageURL(response))
-                .build();
-    }
-
+    // placeId로 Pharmacy 객체 반환
     @Override
     public Pharmacy getPharmacyByPlaceId(String placeId) {
         GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
@@ -70,14 +52,17 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
         return Pharmacy.builder()
                 .name(detailsResult.getName())
                 .placeId(placeId)
-//                .openNow(detailsResult.getOpeningHours().getOpenNow()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
                 .region(getTranslatedLocation(response, detailsResult.getLocationList()))
                 .latitude(detailsResult.getGeometry().getLocation().getLat())
                 .longitude(detailsResult.getGeometry().getLocation().getLng())
                 .country(PharmacyCountry.getCountryByGoogleName(getCountryName(response)))
-//                .periods(detailsResult.getOpeningHours().getPeriods()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
-                .imgUrl(imageUtil.getImageURL(response))
                 .build();
+    }
+
+    @Override
+    public String getImgURLByPlaceId(String placeId) {
+        GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
+        return imageUtil.getImageURL(response);
     }
 
     // 장소 번역

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package com.pharmquest.pharmquest.domain.pharmacy.service;
 import com.pharmquest.pharmquest.domain.medicine.service.TranslationService;
 import com.pharmquest.pharmquest.domain.mypage.web.dto.MyPageResponseDTO;
 import com.pharmquest.pharmquest.domain.pharmacy.ImageUtil;
+import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
 import com.pharmquest.pharmquest.domain.pharmacy.web.dto.GooglePlaceDetailsResponse;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.ErrorStatus;
@@ -57,6 +58,23 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
                 .latitude(detailsResult.getGeometry().getLocation().getLat())
                 .longitude(detailsResult.getGeometry().getLocation().getLng())
                 .country(getCountryName(response))
+//                .periods(detailsResult.getOpeningHours().getPeriods()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
+                .imgUrl(imageUtil.getImageURL(response))
+                .build();
+    }
+
+    @Override
+    public Pharmacy getPharmacyByPlaceId(String placeId) {
+        GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
+        GooglePlaceDetailsResponse.Result detailsResult = response.getResult();
+        return Pharmacy.builder()
+                .name(detailsResult.getName())
+                .placeId(placeId)
+//                .openNow(detailsResult.getOpeningHours().getOpenNow()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
+                .region(getTranslatedLocation(response, detailsResult.getLocationList()))
+                .latitude(detailsResult.getGeometry().getLocation().getLat())
+                .longitude(detailsResult.getGeometry().getLocation().getLng())
+                .country(PharmacyCountry.getCountryByGoogleName(getCountryName(response)))
 //                .periods(detailsResult.getOpeningHours().getPeriods()) // 혹시나 나중에 추가할 수도 있어서 남겨둠
                 .imgUrl(imageUtil.getImageURL(response))
                 .build();


### PR DESCRIPTION
### ✅ Issue
Resolved #230 

## ⛏ 작업 내용
조회 할때마다 번역 할 경우 조회 시간이 오래 걸려, 약국 정보를 담는 테이블을 생성하여 그곳에 약국들의 정보를 저장함.
약국을 스크랩할 때 테이블에 해당 정보가 없다면 약국을 저장한다.
스크랩된 약국 조회 시, User 테이블에서 placeId List를 불러오고, Pharmacy 테이블에서 placeId에 해당하는 약국을 찾아 반환한다.
이렇게 함으로써 번역 작업은 약국이 저장되는 시점에서만 진행하도록 하였다.

## 📌 PR Point
- 이렇게 바꿨는데도 약국 조회 소요시간이 좀 깁니다... 다른 해결방안이 있을지...
