### PR TITLE
feat : 메인화면 게시글 최신순으로 조회

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/domain/home/repository/HomePostRepository.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/home/repository/HomePostRepository.java
@@ -17,6 +17,6 @@ public interface HomePostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findHotPost();
 
     // 최신 게시글 5개 조회
-    List<Post> findTop5ByOrderByCreatedAt();
+    List<Post> findTop5ByOrderByCreatedAtDesc();
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/home/service/HomePostService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/home/service/HomePostService.java
@@ -24,7 +24,7 @@ public class HomePostService {
     // 최식 게시물 5개를 받아와 인기 게시물과 겹치는 하나는 제외
     public List<Post> getNewPosts(Post hotPost){
 
-        List<Post> newPosts = postRepository.findTop5ByOrderByCreatedAt();
+        List<Post> newPosts = postRepository.findTop5ByOrderByCreatedAtDesc();
 
         if(hotPost != null){ // 인기 게시물이 있을 경우 중복 제거
             newPosts.removeIf( post -> post.equals(hotPost));


### PR DESCRIPTION
### ✅ Issue
Resolved #235 

## ⛏ 작업 내용
- 메인화면에서 커뮤니티 게시글 조회 시 최신 순으로 조회하도록 변경

## 📌 PR Point

