### PR TITLE
[Refactor] 약국 스크랩&조회 성능 개선

### DIFF
--- a/src/main/java/com/pharmquest/pharmquest/PharmquestApplication.java
+++ b/src/main/java/com/pharmquest/pharmquest/PharmquestApplication.java
@@ -2,10 +2,8 @@ package com.pharmquest.pharmquest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class PharmquestApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
@@ -28,8 +28,6 @@ import java.util.stream.Collectors;
 public class MyPageConverter {
     private final SupplementsCategoryRepository supplementsCategoryRepository;
     private final SupplementsScrapRepository supplementsScrapRepository;
-    private final PharmacyDetailsService pharmacyDetailsService;
-    private final PharmacyQueryService pharmacyQueryService;
 
     private String processProductName(String name) {
         return name.replaceAll("^\\[(한국|미국|일본)\\]\\s*", "");

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/converter/MyPageConverter.java
@@ -135,7 +135,7 @@ public class MyPageConverter {
                 .build();
     }
 
-    public MyPageResponseDTO.PharmacyDto toPharmacyDto(Pharmacy pharmacy, User user) {
+    public MyPageResponseDTO.PharmacyDto toPharmacyDto(Pharmacy pharmacy, List<String> placeIdList) {
 
         return MyPageResponseDTO.PharmacyDto.builder()
                 .name(pharmacy.getName())
@@ -143,8 +143,8 @@ public class MyPageConverter {
                 .region(pharmacy.getRegion())
                 .latitude(pharmacy.getLatitude())
                 .longitude(pharmacy.getLongitude())
-                .isScrapped(pharmacyQueryService.checkIfScrapPharmacy(pharmacy.getPlaceId(), user))
-                .imgUrl(pharmacyDetailsService.getImgURLByPlaceId(pharmacy.getPlaceId()))
+                .isScrapped(placeIdList.contains(pharmacy.getPlaceId()))
+                .imgUrl(pharmacy.getImgUrl())
                 .build();
     }
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/MyPageServiceImpl.java
@@ -175,7 +175,7 @@ public class MyPageServiceImpl implements MyPageService {
         log.info("구간 1 {}", System.currentTimeMillis() - prev);
         prev = System.currentTimeMillis();
         List<String> pharmacyPlaceIdList = user.getPharmacyScraps();
-        List<Pharmacy> pharmacies = pharmacyRepository.findAllByPlaceIds(pharmacyPlaceIdList);
+        List<Pharmacy> pharmacies = pharmacyRepository.findAllByPlaceIdList(pharmacyPlaceIdList);
 
         log.info("구간 2 {}", System.currentTimeMillis() - prev);
         prev = System.currentTimeMillis();

--- a/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/mypage/service/MyPageServiceImpl.java
@@ -171,15 +171,21 @@ public class MyPageServiceImpl implements MyPageService {
     public Page<MyPageResponseDTO.PharmacyDto> getScrapPharmacies(User user, PharmacyCountry country, Integer page, Integer size) {
 
         // 스크랩된 전체 약국 placeId List
+        long prev = 0;
+        log.info("구간 1 {}", System.currentTimeMillis() - prev);
+        prev = System.currentTimeMillis();
         List<String> pharmacyPlaceIdList = user.getPharmacyScraps();
         List<Pharmacy> pharmacies = pharmacyRepository.findAllByPlaceIds(pharmacyPlaceIdList);
 
+        log.info("구간 2 {}", System.currentTimeMillis() - prev);
+        prev = System.currentTimeMillis();
         // pharmacy list 기반으로 dto 추출
         List<MyPageResponseDTO.PharmacyDto> pharmacyDtoList = pharmacies.stream()
                 .filter(pharmacy -> country.equals(pharmacy.getCountry()) || country.equals(PharmacyCountry.ALL))
-                .map(pharmacy1 -> myPageConverter.toPharmacyDto(pharmacy1, user))
+                .map(pharmacy -> myPageConverter.toPharmacyDto(pharmacy, pharmacyPlaceIdList))
                 .toList();
-
+        log.info("구간 3 {}", System.currentTimeMillis() - prev);
+        prev = System.currentTimeMillis();
         int totalElements = pharmacyDtoList.size();
 
         if (size < 1) { // 사이즈 검증

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/data/Pharmacy.java
@@ -1,5 +1,6 @@
 package com.pharmquest.pharmquest.domain.pharmacy.data;
 
+import com.pharmquest.pharmquest.domain.pharmacy.converter.PlaceIdConverter;
 import com.pharmquest.pharmquest.domain.pharmacy.data.enums.PharmacyCountry;
 import com.pharmquest.pharmquest.global.data.BaseEntity;
 import jakarta.persistence.*;
@@ -33,6 +34,10 @@ public class Pharmacy extends BaseEntity {
 
     @Column(nullable = false)
     private Double longitude;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String imgUrl;
 
 }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/repository/PharmacyRepository.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 public interface PharmacyRepository extends JpaRepository<Pharmacy, Long> {
 
-    public Boolean existsByPlaceId(String placeId);
+    Boolean existsByPlaceId(String placeId);
 
     @Query(value = "SELECT * FROM pharmacy WHERE place_id IN (:placeIds)", nativeQuery = true)
-    List<Pharmacy> findAllByPlaceIds(@Param("placeIds") List<String> placeIds);
+    List<Pharmacy> findAllByPlaceIdList(@Param("placeIds") List<String> placeIdList);
 
 
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandService.java
@@ -1,10 +1,9 @@
 package com.pharmquest.pharmquest.domain.pharmacy.service;
 
-import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 import com.pharmquest.pharmquest.domain.user.data.User;
 import com.pharmquest.pharmquest.global.apiPayload.code.status.SuccessStatus;
 
 public interface PharmacyCommandService {
-    public SuccessStatus scrapPharmacy(User user, String placeId);
-    public Pharmacy savePharmacy(String placeId);
+    SuccessStatus scrapPharmacy(User user, String placeId);
+    void savePharmacy(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -42,8 +42,6 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
             // placeId 검증
             if(placeId == null || placeId.isEmpty()) { // 값이 없음
                 throw new CommonExceptionHandler(ErrorStatus.PHARMACY_PLACE_ID_NULL);
-            }else if(!pharmacyDetailsService.isPharmacyByPlaceId(placeId)) { // placeId에 해당하는 장소가 약국이 아님
-                throw new CommonExceptionHandler(ErrorStatus.NOT_A_PHARMACY);
             }
 
             // 스크랩 목록에 placeId 추가

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyCommandServiceImpl.java
@@ -67,8 +67,8 @@ public class PharmacyCommandServiceImpl implements PharmacyCommandService {
     }
 
     @Override
-    public Pharmacy savePharmacy(String placeId) {
+    public void savePharmacy(String placeId) {
         Pharmacy pharmacy = pharmacyDetailsService.getPharmacyByPlaceId(placeId);
-        return pharmacyRepository.save(pharmacy);
+        pharmacyRepository.save(pharmacy);
     }
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsService.java
@@ -4,7 +4,5 @@ import com.pharmquest.pharmquest.domain.pharmacy.data.Pharmacy;
 
 
 public interface PharmacyDetailsService {
-    public Boolean isPharmacyByPlaceId(String placeId);
     public Pharmacy getPharmacyByPlaceId(String placeId);
-    public String getImgURLByPlaceId(String placeId);
 }

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -48,6 +48,11 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
     public Pharmacy getPharmacyByPlaceId(String placeId) {
         GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
         GooglePlaceDetailsResponse.Result detailsResult = response.getResult();
+
+        if (!checkIfPharmacy(response)) {
+            throw new CommonExceptionHandler(ErrorStatus.NOT_A_PHARMACY);
+        }
+
         return Pharmacy.builder()
                 .name(detailsResult.getName())
                 .placeId(placeId)

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -55,6 +55,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
                 .latitude(detailsResult.getGeometry().getLocation().getLat())
                 .longitude(detailsResult.getGeometry().getLocation().getLng())
                 .country(PharmacyCountry.getCountryByGoogleName(getCountryName(response)))
+                .imgUrl(imageUtil.getPharmacyImageURL(response))
                 .build();
     }
 

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -32,17 +32,6 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
         this.imageUtil = imageUtil;
     }
 
-    @Override
-    public Boolean isPharmacyByPlaceId(String placeId) {
-
-        GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
-        if ("OK".equals(response.getStatus())) {
-            return checkIfPharmacy(response);
-        }
-        // 구글에서 가져온 응답의 status가 OK 아니면 그냥 약국 아닌걸로
-        return false;
-    }
-
     // placeId로 Pharmacy 객체 반환
     @Override
     public Pharmacy getPharmacyByPlaceId(String placeId) {
@@ -62,12 +51,6 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
                 .country(PharmacyCountry.getCountryByGoogleName(getCountryName(response)))
                 .imgUrl(imageUtil.getPharmacyImageURL(response))
                 .build();
-    }
-
-    @Override
-    public String getImgURLByPlaceId(String placeId) {
-        GooglePlaceDetailsResponse response = getDetailsByPlaceId(placeId);
-        return imageUtil.getPharmacyImageURL(response);
     }
 
     // 장소 번역
@@ -112,6 +95,10 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
 
     // api로부터 불러온 정보를 바탕으로 약국인지 확인
     private Boolean checkIfPharmacy(GooglePlaceDetailsResponse response) {
+
+        if ("OK".equals(response.getStatus())) {
+            return checkIfPharmacy(response);
+        }
 
         if (response != null && response.getResult() != null && response.getResult().getTypes() != null) {
             List<String> types = response.getResult().getTypes();

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -83,6 +83,7 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
 
     // placeId를 가지고 api로 상세정보 조회
     private GooglePlaceDetailsResponse getDetailsByPlaceId(String placeId) {
+        log.info("google place api 호출");
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("key", API_KEY)

--- a/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/pharmacy/service/PharmacyDetailsServiceImpl.java
@@ -96,8 +96,8 @@ public class PharmacyDetailsServiceImpl implements PharmacyDetailsService {
     // api로부터 불러온 정보를 바탕으로 약국인지 확인
     private Boolean checkIfPharmacy(GooglePlaceDetailsResponse response) {
 
-        if ("OK".equals(response.getStatus())) {
-            return checkIfPharmacy(response);
+        if (!"OK".equals(response.getStatus())) {
+            return false;
         }
 
         if (response != null && response.getResult() != null && response.getResult().getTypes() != null) {

--- a/src/main/java/com/pharmquest/pharmquest/domain/post/service/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/pharmquest/pharmquest/domain/post/service/post/PostCommandServiceImpl.java
@@ -24,6 +24,7 @@ import com.pharmquest.pharmquest.global.apiPayload.exception.handler.PostHandler
 import com.pharmquest.pharmquest.global.service.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostCommandServiceImpl implements PostCommandService {
 
     private final PostRepository postRepository;
@@ -108,7 +110,6 @@ public class PostCommandServiceImpl implements PostCommandService {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_EXIST));
-
         boolean isLiked = likeRepository.existsByPostIdAndUserId(postId, userId);
         boolean isScrapped = scrapRepository.existsByPostIdAndUserId(postId, userId);
         boolean isOwnPost = userId.equals(post.getUser().getId());


### PR DESCRIPTION
### ✅ Issue
Resolved #245 

## ⛏ 작업 내용
- 마이페이지 약국 조회 성능 개선
- 약국 스크랩 기능 성능 개선
- google place api 요청 로그 추가

## 📌 PR Point
- Base64 변환할 때 시간이 꽤 걸렸었습니다. 알아보니 Base64 URL은 유효기간이 없다고 해서, 조회할 때마다 url 변환했던 기존에서 변환된 url을 pharmacy 테이블의 컬럼으로 저장하였습니다. 결과적으로 성능 아주 good 해짐
- 스크랩 할때마다 google api 요청해서 약국 여부를 체크하고 있기에 스크랩 해제보다 시간이 걸린다는걸 확인함.
  -> api 요청 보내지 않게 변경
- google place api 요청 보낼 시 로그 발생시켜 불필요한 api 요청 확인할 수 있도록 함.
